### PR TITLE
Update image-utils version to fix the semver vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "readmeFilename": "README.md",
     "homepage": "https://github.com/Pushwoosh/pushwoosh-expo-plugin",
     "dependencies": {
-        "@expo/image-utils": "^0.3.22"
+        "@expo/image-utils": "^0.5.1"
     },
     "devDependencies": {
         "expo-module-scripts": "~4.0.4",


### PR DESCRIPTION
"@expo/image-utils": "^0.3.22" includes semver": "7.3.2", which has [Regular Expression Denial of Service (ReDoS) vulnerability](https://security.snyk.io/package/npm/semver/7.3.2).
The version is updated to "0.5.1", which includes "semver": "^7.6.0", that fixes the issue